### PR TITLE
Fix callable save_to dispatch (UnboundLocalError) and stop leaking secrets in KeyError

### DIFF
--- a/config2py/base.py
+++ b/config2py/base.py
@@ -246,10 +246,21 @@ class FuncBasedGettableContainer:
     ``FuncBasedGettableContainer`` raises a ``KeyError``, to conform to the
     ``Mapping`` protocol.
 
-    >>> gc['no_a_key']  # doctest: +ELLIPSIS +IGNORE_EXCEPTION_DETAIL
+    >>> gc['no_a_key']
     Traceback (most recent call last):
     ...
-    KeyError: 'There was an exception ... : "I don\'t handle that: no_a_key"'
+    KeyError: 'no_a_key'
+
+    The ``KeyError`` message is just the key: neither the upstream exception text nor
+    the rejected value is interpolated into it, since getters commonly wrap credential
+    checks and these errors commonly end up in logs. The upstream exception is still
+    available, through the standard exception chain:
+
+    >>> try:
+    ...     gc['no_a_key']
+    ... except KeyError as e:
+    ...     print(type(e.__cause__).__name__, e.__cause__, sep=': ')
+    RuntimeError: I don't handle that: no_a_key
 
     Note that by default, ``FuncBasedGettableContainer`` will catch all ``Exception``
     exceptions, but you can specify a different set of exceptions to catch.
@@ -274,7 +285,7 @@ class FuncBasedGettableContainer:
     >>> gc['no_a_key']
     Traceback (most recent call last):
     ...
-    KeyError: 'Value for key no_a_key is not valid: None'
+    KeyError: 'no_a_key'
 
     """
 
@@ -296,12 +307,17 @@ class FuncBasedGettableContainer:
         try:
             v = self.getter(k)
         except self.config_not_found_exceptions as e:
-            raise KeyError(
-                f"There was an exception when computing key: {k} with the function "
-                f"{self.getter}. The exception was: {e}"
-            )
+            # Note: The upstream exception text is deliberately NOT interpolated into
+            # the message. Getters here often wrap credential validation, and SDKs
+            # routinely echo the rejected secret back in their exception text
+            # ("authentication failed for token sk-..."). These KeyErrors are caught
+            # and logged by callers, so anything in the message ends up in logs.
+            # The upstream exception remains reachable via ``__cause__``.
+            raise KeyError(k) from e
         if not self.val_is_valid(v):
-            raise KeyError(f"Value for key {k} is not valid: {v}")
+            # Same reasoning: ``v`` is the *rejected* value, which is precisely the
+            # thing that is often a secret (that's why it's being validated).
+            raise KeyError(k)
         return v
 
     # TODO: Is this used to indicate that the getter couldn't find a key.
@@ -358,6 +374,66 @@ KTSaver = Callable[[KT, VT], Any]
 SaveTo = Optional[Union[MutableMapping, KTSaver]]
 
 
+def _resolve_saver(save_to: SaveTo) -> Optional[KTSaver]:
+    """Resolve a ``SaveTo`` specification into a ``(key, value)`` saver function.
+
+    This is the single place where the ``SaveTo`` union is interpreted, so every
+    function that accepts a ``save_to`` agrees on what it means.
+
+    ``None`` means "don't save", and is passed through as such:
+
+    >>> _resolve_saver(None) is None
+    True
+
+    Anything with a ``__setitem__`` (any ``MutableMapping``, but also the write-only
+    stores that ``dol`` makes) saves through that ``__setitem__``:
+
+    >>> d = {}
+    >>> save = _resolve_saver(d)
+    >>> save('some_key', 'some_value')
+    >>> d
+    {'some_key': 'some_value'}
+
+    A callable is used as the saver itself:
+
+    >>> saved = []
+    >>> save = _resolve_saver(lambda k, v: saved.append((k, v)))
+    >>> save('some_key', 'some_value')
+    >>> saved
+    [('some_key', 'some_value')]
+
+    Resolution is idempotent, so an already-resolved saver can be passed around
+    (and re-resolved) freely:
+
+    >>> _resolve_saver(save) is save
+    True
+
+    Anything else is an error, named as such instead of failing obscurely (or
+    silently dropping the value) at save time:
+
+    >>> _resolve_saver(42)  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    ...
+    TypeError: save_to must be None, a MutableMapping ... Got type: int
+
+    """
+    if save_to is None:
+        return None
+    elif hasattr(save_to, "__setitem__"):
+        # Note: We test for ``__setitem__`` rather than ``isinstance(.., MutableMapping)``
+        # so that write-only stores (which don't implement the full MutableMapping
+        # interface) keep working. Mappings win over callables when an object is both.
+        return save_to.__setitem__
+    elif callable(save_to):
+        return save_to
+    else:
+        raise TypeError(
+            "save_to must be None, a MutableMapping (or anything with a __setitem__), "
+            "or a callable taking (key, value). "
+            f"Got type: {type(save_to).__name__}"
+        )
+
+
 def is_not_empty(val) -> bool:
     if isinstance(val, str):
         return val != ""
@@ -374,11 +450,51 @@ def ask_user_for_key(
     user_asker=ask_user_for_input,
     egress: Callable | None = None,
 ):
+    """Ask the user for the value of ``key``, optionally saving it.
+
+    :param key: The key to ask the user for. If ``None``, a "curried" version of
+        ``ask_user_for_key`` is returned, so you can specify the key later.
+    :param prompt_template: A template string to prompt the user with. It should
+        contain a placeholder for the key, e.g. ``"Enter a value for {}: "``.
+    :param save_to: Where to save the user's response: a ``MutableMapping`` (or
+        anything with a ``__setitem__``), or a ``(key, value)`` saver function.
+        If ``None``, the response is not saved. See ``_resolve_saver``.
+    :param save_condition: A function of the value, deciding whether to save it.
+    :param user_asker: A function that takes a prompt string and returns the user's
+        response.
+    :param egress: A ``(key, value)`` function to apply to the user's response before
+        returning (and saving) it.
+
+    The value can be saved to any ``MutableMapping``:
+
+    >>> store = {}
+    >>> ask_user_for_key('some_key', save_to=store, user_asker=lambda prompt: 'val')
+    'val'
+    >>> store
+    {'some_key': 'val'}
+
+    ... or to a ``(key, value)`` function, when saving isn't a simple write:
+
+    >>> saved = []
+    >>> ask_user_for_key(
+    ...     'some_key',
+    ...     save_to=lambda k, v: saved.append((k, v)),
+    ...     user_asker=lambda prompt: 'val',
+    ... )
+    'val'
+    >>> saved
+    [('some_key', 'val')]
+
+    """
+    # Note: We resolve ``save_to`` up front (and carry the resolved saver into the
+    # curried form) so that an unusable ``save_to`` is reported when it's specified,
+    # not after the user has already typed a value we then can't save.
+    saver = _resolve_saver(save_to)
     if key is None:
         return partial(
             ask_user_for_key,
             prompt_template=prompt_template,
-            save_to=save_to,
+            save_to=saver,
             save_condition=save_condition,
             user_asker=user_asker,
             egress=egress,
@@ -386,10 +502,8 @@ def ask_user_for_key(
     val = user_asker(prompt_template.format(key))
     if isinstance(egress, Callable):
         val = egress(key, val)
-    if save_to is not None and save_condition(val):
-        if hasattr(save_to, "__setitem__"):
-            save_to_func = save_to.__setitem__
-        save_to_func(key, val)
+    if saver is not None and save_condition(val):
+        saver(key, val)
     return val
 
 
@@ -405,8 +519,9 @@ def user_gettable(
     """
     Create a ``GettableContainer`` that asks the user for a value, optionally saving it.
 
-    :param save_to: A ``MutableMapping`` to save the user's response to. If ``None``,
-        the user's response is not saved.
+    :param save_to: Where to save the user's response: a ``MutableMapping`` (or
+        anything with a ``__setitem__``), or a ``(key, value)`` saver function.
+        If ``None``, the user's response is not saved.
     :param prompt_template: A template string to prompt the user with. It should
         contain a placeholder for the key, e.g. ``"Enter a value for {}: "``.
     :param egress: A function to apply to the user's response before returning it.
@@ -439,6 +554,19 @@ def user_gettable(
     'SOME_VAL'
     >>> d  # doctest: +SKIP
     {'some': 'store', 'SOME_KEY': 'SOME_VAL'}
+
+    When saving isn't a simple write (say you need to encrypt, or write to two
+    places), ``save_to`` can be a ``(key, value)`` function instead:
+
+    >>> saved = []
+    >>> s = user_gettable(
+    ...     save_to=lambda k, v: saved.append((k, v)),
+    ...     user_asker=lambda prompt: 'SOME_VAL',
+    ... )
+    >>> s['SOME_KEY']
+    'SOME_VAL'
+    >>> saved
+    [('SOME_KEY', 'SOME_VAL')]
 
     """
     getter = ask_user_for_key(

--- a/config2py/tests/test_app_data.py
+++ b/config2py/tests/test_app_data.py
@@ -7,18 +7,42 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from config2py.util import ensure_seeded, AppData
+from config2py.util import ensure_seeded, AppData, config2py_env_var
+
+
+def _redirect_app_root(folder_kind: str, target):
+    """Redirect a config2py app-root folder kind at *target* for the test.
+
+    Uses config2py's own ``CONFIG2PY_<KIND>_DIR`` override, which is honoured on
+    every platform.  The XDG_* variables must NOT be used here: they are a POSIX
+    standard and are ignored on Windows, so tests keyed on them silently write
+    into the real user profile instead of the temp dir.
+    """
+    env_var = getattr(config2py_env_var, folder_kind)
+    return patch.dict(os.environ, {env_var: str(target)})
+
+
+def _same_path(a, b) -> bool:
+    """Compare two paths by identity-on-disk, not by their string spelling.
+
+    ``resolve()`` on both sides normalises the differences that make naive
+    string comparison fail per-platform: macOS ``/var`` -> ``/private/var``
+    symlinks, and Windows 8.3 short names (``RUNNER~1`` -> ``runneradmin``).
+    """
+    return Path(a).resolve() == Path(b).resolve()
 
 
 # ---------------------------------------------------------------------------
 # Helpers — mock importlib.resources for isolated testing
 # ---------------------------------------------------------------------------
 
+
 def _mock_importlib_files(seed_store: dict):
     """Return a mock for importlib.resources.files that reads from *seed_store*.
 
     *seed_store* maps ``(subpackage, filename)`` to ``bytes`` content.
     """
+
     def fake_files(package_path: str):
         # Extract subpackage from e.g. "mypkg._seed_data.resources"
         parts = package_path.split(".")
@@ -36,6 +60,7 @@ def _mock_importlib_files(seed_store: dict):
                 return mock_ref
 
         return FakeTraversable()
+
     return fake_files
 
 
@@ -110,6 +135,7 @@ class TestEnsureSeeded:
     def test_custom_seed_data_dir(self, tmp_path):
         """Ensure the seed_data_dir parameter is used in the package path."""
         calls = []
+
         def fake_files(pkg_path):
             calls.append(pkg_path)
             mock = MagicMock()
@@ -121,7 +147,10 @@ class TestEnsureSeeded:
         target = tmp_path / "file.txt"
         with patch("importlib.resources.files", side_effect=fake_files):
             ensure_seeded(
-                target, "mypkg", "resources", "file.txt",
+                target,
+                "mypkg",
+                "resources",
+                "file.txt",
                 seed_data_dir="my_seeds",
             )
         assert calls[0] == "mypkg.my_seeds.resources"
@@ -145,21 +174,22 @@ class TestAppData:
         assert app.package_name == "my_app"
 
     def test_app_folder_creates_directory(self, tmp_path):
-        with patch.dict(os.environ, {"XDG_DATA_HOME": str(tmp_path)}):
+        with _redirect_app_root("data", tmp_path):
             app = AppData("testapp")
             folder = app.app_folder(folder_kind="data")
             assert folder.is_dir()
             assert folder.name == "testapp"
+            assert _same_path(folder, tmp_path / "testapp")
 
     def test_app_folder_config(self, tmp_path):
-        with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path)}):
+        with _redirect_app_root("config", tmp_path):
             app = AppData("testapp")
             folder = app.app_folder(folder_kind="config")
             assert folder.is_dir()
-            assert folder == tmp_path / "testapp"
+            assert _same_path(folder, tmp_path / "testapp")
 
     def test_get_resource_seeds_when_missing(self, tmp_path):
-        with patch.dict(os.environ, {"XDG_DATA_HOME": str(tmp_path)}):
+        with _redirect_app_root("data", tmp_path):
             with patch(
                 "importlib.resources.files",
                 side_effect=_mock_importlib_files(SEED_STORE),
@@ -168,10 +198,12 @@ class TestAppData:
                 path = app.get_resource("hello.txt")
                 assert path.exists()
                 assert path.read_bytes() == b"hello world\nline two\n"
-                assert "resources" in str(path)
+                assert _same_path(
+                    path, tmp_path / "testapp" / "resources" / "hello.txt"
+                )
 
     def test_get_resource_preserves_user_edits(self, tmp_path):
-        with patch.dict(os.environ, {"XDG_DATA_HOME": str(tmp_path)}):
+        with _redirect_app_root("data", tmp_path):
             with patch(
                 "importlib.resources.files",
                 side_effect=_mock_importlib_files(SEED_STORE),
@@ -184,7 +216,7 @@ class TestAppData:
                 assert path2.read_text() == "edited by user"
 
     def test_get_config_seeds_when_missing(self, tmp_path):
-        with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path)}):
+        with _redirect_app_root("config", tmp_path):
             with patch(
                 "importlib.resources.files",
                 side_effect=_mock_importlib_files(SEED_STORE),
@@ -194,16 +226,17 @@ class TestAppData:
                 assert path.exists()
                 data = json.loads(path.read_text())
                 assert data["tempo"] == 120
+                assert _same_path(path, tmp_path / "testapp" / "defaults.json")
 
     def test_get_artifact_dir_creates_subdir(self, tmp_path):
-        with patch.dict(os.environ, {"XDG_DATA_HOME": str(tmp_path)}):
+        with _redirect_app_root("data", tmp_path):
             app = AppData("testapp")
             midi_dir = app.get_artifact_dir("midi")
             assert midi_dir.is_dir()
-            assert midi_dir == tmp_path / "testapp" / "artifacts" / "midi"
+            assert _same_path(midi_dir, tmp_path / "testapp" / "artifacts" / "midi")
 
     def test_get_artifact_dir_multiple_kinds(self, tmp_path):
-        with patch.dict(os.environ, {"XDG_DATA_HOME": str(tmp_path)}):
+        with _redirect_app_root("data", tmp_path):
             app = AppData("testapp")
             for kind in ("midi", "audio", "exports"):
                 d = app.get_artifact_dir(kind)

--- a/config2py/tests/test_base.py
+++ b/config2py/tests/test_base.py
@@ -1,0 +1,161 @@
+"""Tests for ``config2py.base``: ``save_to`` dispatch and leak-free ``KeyError``s."""
+
+import pytest
+
+from config2py.base import (
+    FuncBasedGettableContainer,
+    ask_user_for_key,
+    user_gettable,
+)
+
+# A stand-in for a credential. Used to assert that a rejected value (or the upstream
+# exception text that echoes it) never reaches an error message.
+SECRET = "sk-secret-1234"
+
+
+def _constant_asker(value):
+    """Make a ``user_asker`` that answers ``value`` without touching stdin."""
+    return lambda prompt: value
+
+
+class _SetItemOnlyStore:
+    """A write target that has ``__setitem__`` but is not a ``MutableMapping``.
+
+    Stands in for the write-only stores that ``dol`` (and friends) hand out.
+    """
+
+    def __init__(self):
+        self.written = {}
+
+    def __setitem__(self, k, v):
+        self.written[k] = v
+
+
+# --------------------------------------------------------------------------------
+# save_to dispatch
+
+
+def test_ask_user_for_key_saves_to_mapping():
+    store = {}
+    val = ask_user_for_key("K", save_to=store, user_asker=_constant_asker("V"))
+    assert val == "V"
+    assert store == {"K": "V"}
+
+
+def test_ask_user_for_key_saves_to_setitem_only_store():
+    store = _SetItemOnlyStore()
+    val = ask_user_for_key("K", save_to=store, user_asker=_constant_asker("V"))
+    assert val == "V"
+    assert store.written == {"K": "V"}
+
+
+def test_ask_user_for_key_saves_to_callable_saver():
+    saved = []
+    val = ask_user_for_key(
+        "K",
+        save_to=lambda k, v: saved.append((k, v)),
+        user_asker=_constant_asker("V"),
+    )
+    assert val == "V"
+    assert saved == [("K", "V")]
+
+
+def test_ask_user_for_key_rejects_unusable_save_to():
+    with pytest.raises(TypeError) as excinfo:
+        ask_user_for_key("K", save_to=42, user_asker=_constant_asker("V"))
+    # The error names the offending type, but never the value being saved
+    assert "int" in str(excinfo.value)
+
+
+def test_ask_user_for_key_rejects_unusable_save_to_before_prompting():
+    """An unusable ``save_to`` is reported at wiring time, not after the user typed."""
+    asked = []
+
+    def recording_asker(prompt):
+        asked.append(prompt)
+        return "V"
+
+    with pytest.raises(TypeError):
+        ask_user_for_key("K", save_to=object(), user_asker=recording_asker)
+    assert asked == [], "the user should not be prompted for a value we cannot save"
+
+
+def test_ask_user_for_key_does_not_save_when_condition_is_false():
+    saved = []
+    val = ask_user_for_key(
+        "K",
+        save_to=lambda k, v: saved.append((k, v)),
+        user_asker=_constant_asker(""),
+    )
+    assert val == ""
+    assert saved == []
+
+
+def test_user_gettable_with_mapping_saver():
+    store = {}
+    s = user_gettable(save_to=store, user_asker=_constant_asker("SOME_VAL"))
+    assert s["SOME_KEY"] == "SOME_VAL"
+    assert store == {"SOME_KEY": "SOME_VAL"}
+
+
+def test_user_gettable_with_callable_saver():
+    saved = {}
+    s = user_gettable(
+        save_to=lambda k, v: saved.update({k: v}),
+        user_asker=_constant_asker("SOME_VAL"),
+    )
+    assert s["SOME_KEY"] == "SOME_VAL"
+    assert saved == {"SOME_KEY": "SOME_VAL"}
+
+
+def test_user_gettable_rejects_unusable_save_to():
+    with pytest.raises(TypeError):
+        user_gettable(save_to=42)
+
+
+# --------------------------------------------------------------------------------
+# KeyError messages must not leak secrets (issue #14)
+
+
+def test_getter_exception_keyerror_does_not_leak_secret():
+    def getter(k):
+        raise RuntimeError(f"authentication failed for token {SECRET}")
+
+    gc = FuncBasedGettableContainer(getter)
+    with pytest.raises(KeyError) as excinfo:
+        gc["API_KEY"]
+    assert SECRET not in str(excinfo.value)
+    assert SECRET not in repr(excinfo.value)
+    assert excinfo.value.args[0] == "API_KEY"
+
+
+def test_getter_exception_keyerror_keeps_cause():
+    """The upstream exception stays reachable -- just not embedded in the message."""
+
+    def getter(k):
+        raise RuntimeError(f"authentication failed for token {SECRET}")
+
+    gc = FuncBasedGettableContainer(getter)
+    with pytest.raises(KeyError) as excinfo:
+        gc["API_KEY"]
+    cause = excinfo.value.__cause__
+    assert isinstance(cause, RuntimeError)
+    assert SECRET in str(cause)
+
+
+def test_invalid_value_keyerror_does_not_leak_rejected_value():
+    gc = FuncBasedGettableContainer(lambda k: SECRET, val_is_valid=lambda v: False)
+    with pytest.raises(KeyError) as excinfo:
+        gc["API_KEY"]
+    assert SECRET not in str(excinfo.value)
+    assert SECRET not in repr(excinfo.value)
+    assert excinfo.value.args[0] == "API_KEY"
+
+
+def test_contains_still_works_with_leak_free_errors():
+    """``__contains__`` relies on the ``KeyError``, so it must survive the change."""
+    gc = FuncBasedGettableContainer(
+        lambda k: k if k == "there" else None, val_is_valid=lambda v: v is not None
+    )
+    assert "there" in gc
+    assert "not_there" not in gc

--- a/config2py/tests/test_platform_standards.py
+++ b/config2py/tests/test_platform_standards.py
@@ -1,0 +1,102 @@
+"""Cross-platform tests for the app-folder standards table.
+
+``config2py.util.app_folder_standards`` is the single place where config2py
+branches on the operating system.  Because it takes the ``os.name`` to resolve
+for as an argument, these tests exercise *both* platforms' tables from whatever
+platform happens to be running -- Windows behaviour is verified on Linux/macOS
+and vice versa.
+"""
+
+import os
+from typing import get_args
+
+import pytest
+
+from config2py.util import (
+    APP_FOLDER_STANDARDS,
+    AppFolderKind,
+    app_folder_standards,
+    config2py_env_var,
+    get_app_rootdir,
+    system_default_for_app_data_folder,
+)
+
+#: The ``os.name`` values config2py distinguishes between.
+OS_NAMES = ("nt", "posix")
+
+#: Every folder kind config2py knows about.
+FOLDER_KINDS = tuple(APP_FOLDER_STANDARDS)
+
+#: Environment values standing in for a real Windows user profile.
+WINDOWS_ENV = {
+    "APPDATA": r"C:\Users\someone\AppData\Roaming",
+    "LOCALAPPDATA": r"C:\Users\someone\AppData\Local",
+    "TEMP": r"C:\Users\someone\AppData\Local\Temp",
+}
+
+
+@pytest.mark.parametrize("os_name", OS_NAMES)
+def test_every_kind_is_specified_on_every_platform(os_name):
+    """Both platform tables cover exactly the kinds the type allows."""
+    standards = app_folder_standards(os_name)
+    assert set(standards) == set(get_args(AppFolderKind))
+
+
+@pytest.mark.parametrize("os_name", OS_NAMES)
+@pytest.mark.parametrize("folder_kind", FOLDER_KINDS)
+def test_defaults_are_nonempty(os_name, folder_kind, monkeypatch):
+    """A missing platform env var must still yield a usable root, never ''.
+
+    An empty root silently degrades ``os.path.join(root, app_name)`` into a
+    *relative* path, which would scatter app folders into the CWD.
+    """
+    standards = app_folder_standards(os_name)
+    for spec in standards.values():
+        monkeypatch.delenv(spec.env_var, raising=False)
+    resolved = system_default_for_app_data_folder(folder_kind, standards=standards)
+    assert resolved
+    assert not resolved.endswith(("/", "\\"))
+
+
+def test_windows_cache_is_not_the_data_folder(monkeypatch):
+    """Regression: on Windows 'cache' must not collide with 'data'/'state'.
+
+    Both are rooted at %LOCALAPPDATA%, so 'cache' has to live in a sub-folder.
+    When they collided, clearing an app's cache would delete the user's data.
+    """
+    standards = app_folder_standards("nt")
+    for name, value in WINDOWS_ENV.items():
+        monkeypatch.setenv(name, value)
+    resolved = {
+        kind: system_default_for_app_data_folder(kind, standards=standards)
+        for kind in standards
+    }
+    assert resolved["cache"] != resolved["data"]
+    assert resolved["cache"] != resolved["state"]
+    # ... and it is the documented %LOCALAPPDATA%\Temp, i.e. *inside* the root
+    assert os.path.basename(resolved["cache"]) == "Temp"
+    assert os.path.dirname(resolved["cache"]) == resolved["data"]
+
+
+@pytest.mark.parametrize("os_name", OS_NAMES)
+def test_posix_only_xdg_vars_are_absent_from_the_windows_table(os_name):
+    """XDG_* is a POSIX standard; the Windows table must not name those vars."""
+    standards = app_folder_standards(os_name)
+    env_vars = {spec.env_var for spec in standards.values()}
+    if os_name == "nt":
+        assert not any(v.startswith("XDG_") for v in env_vars)
+    else:
+        assert all(v.startswith("XDG_") for v in env_vars)
+
+
+@pytest.mark.parametrize("folder_kind", FOLDER_KINDS)
+def test_config2py_override_wins_on_every_platform(folder_kind, tmp_path, monkeypatch):
+    """``CONFIG2PY_<KIND>_DIR`` is the platform-neutral override.
+
+    Unlike XDG_*, it is honoured on Windows too -- which is what makes it the
+    right knob for tests and for users who need to relocate app folders.
+    """
+    target = tmp_path / folder_kind
+    monkeypatch.setenv(getattr(config2py_env_var, folder_kind), str(target))
+    rootdir = get_app_rootdir(folder_kind, ensure_exists=True)
+    assert os.path.realpath(rootdir) == os.path.realpath(str(target))

--- a/config2py/tests/test_platform_standards.py
+++ b/config2py/tests/test_platform_standards.py
@@ -15,6 +15,7 @@ import pytest
 from config2py.util import (
     APP_FOLDER_STANDARDS,
     AppFolderKind,
+    FolderSpec,
     app_folder_standards,
     config2py_env_var,
     get_app_rootdir,
@@ -34,12 +35,52 @@ WINDOWS_ENV = {
     "TEMP": r"C:\Users\someone\AppData\Local\Temp",
 }
 
+#: The two platform tables, spelled out exactly as ``get_app_rootdir``'s docstring
+#: promises them, as ``{os_name: {folder_kind: (env_var, default_path, subpath)}}``.
+#:
+#: Every other test here checks *structural* properties -- non-empty, no
+#: collisions, right variable family -- which a silently-retargeted default would
+#: still satisfy. This is the one place the literals themselves are pinned, so
+#: that changing where config2py puts a user's files is necessarily a deliberate,
+#: visible edit to both the table and this expectation.
+DOCUMENTED_STANDARDS = {
+    "posix": {
+        "config": ("XDG_CONFIG_HOME", "~/.config", ""),
+        "data": ("XDG_DATA_HOME", "~/.local/share", ""),
+        "cache": ("XDG_CACHE_HOME", "~/.cache", ""),
+        "state": ("XDG_STATE_HOME", "~/.local/state", ""),
+        "runtime": ("XDG_RUNTIME_DIR", "/tmp", ""),
+    },
+    "nt": {
+        "config": ("APPDATA", r"~\AppData\Roaming", ""),
+        "data": ("LOCALAPPDATA", r"~\AppData\Local", ""),
+        "cache": ("LOCALAPPDATA", r"~\AppData\Local", "Temp"),
+        "state": ("LOCALAPPDATA", r"~\AppData\Local", ""),
+        "runtime": ("TEMP", r"~\AppData\Local\Temp", ""),
+    },
+}
+
 
 @pytest.mark.parametrize("os_name", OS_NAMES)
 def test_every_kind_is_specified_on_every_platform(os_name):
     """Both platform tables cover exactly the kinds the type allows."""
     standards = app_folder_standards(os_name)
     assert set(standards) == set(get_args(AppFolderKind))
+
+
+@pytest.mark.parametrize("os_name", OS_NAMES)
+def test_tables_match_the_documented_standards(os_name):
+    """The tables hold the exact roots the documentation advertises.
+
+    Where a user's config, data, cache, state and runtime files land is public
+    API: dependents and end users rely on those paths. Pinning the literals
+    means a change of location cannot slip in as a side effect of an unrelated
+    edit -- it has to be written down here too.
+    """
+    expected = {
+        kind: FolderSpec(*spec) for kind, spec in DOCUMENTED_STANDARDS[os_name].items()
+    }
+    assert app_folder_standards(os_name) == expected
 
 
 @pytest.mark.parametrize("os_name", OS_NAMES)

--- a/config2py/tests/test_sync_store.py
+++ b/config2py/tests/test_sync_store.py
@@ -270,7 +270,14 @@ def test_store_repr():
     try:
         file_store = FileStore(temp_file)
         assert "FileStore" in repr(file_store)
-        assert temp_file in repr(file_store)
+        # The repr embeds ``repr(self.filepath)``, and pathlib's repr always
+        # spells the path with forward slashes (``PurePath.__repr__`` uses
+        # ``as_posix()``) -- so on Windows it never contains the native
+        # backslash form of ``temp_file``. Assert the *identity* of the path the
+        # store is bound to, plus the separator-free filename in the repr,
+        # rather than comparing separator-laden strings.
+        assert file_store.filepath == Path(temp_file)
+        assert Path(temp_file).name in repr(file_store)
 
         file_store_with_path = FileStore(temp_file, key_path="section")
         assert "key_path" in repr(file_store_with_path)

--- a/config2py/util.py
+++ b/config2py/util.py
@@ -262,26 +262,67 @@ def create_directories(dirpath, max_dirs_to_make=None):
     return True
 
 
-FolderSpec = namedtuple("FolderSpec", ["env_var", "default_path"])
+#: Declarative description of where a given folder kind lives on a platform.
+#:
+#: ``env_var`` is the platform-standard environment variable that, when set,
+#: names the *root* folder.  ``default_path`` is the root to use when that
+#: variable is absent (``~`` is expanded).  ``subpath`` is a relative path
+#: appended to the root; it exists because some platform standards place a
+#: folder kind *inside* another kind's root rather than under its own variable
+#: (e.g. Windows cache lives at ``%LOCALAPPDATA%\\Temp``).
+FolderSpec = namedtuple(
+    "FolderSpec", ["env_var", "default_path", "subpath"], defaults=("",)
+)
 
-if os.name == "nt":
-    APP_FOLDER_STANDARDS = dict(
-        config=FolderSpec("APPDATA", os.getenv("APPDATA", "")),
-        data=FolderSpec("LOCALAPPDATA", os.getenv("LOCALAPPDATA", "")),
-        cache=FolderSpec(
-            "LOCALAPPDATA", os.path.join(os.getenv("LOCALAPPDATA", ""), "Temp")
-        ),
-        state=FolderSpec("LOCALAPPDATA", os.getenv("LOCALAPPDATA", "")),
-        runtime=FolderSpec("TEMP", os.getenv("TEMP", "")),
-    )
-else:
-    APP_FOLDER_STANDARDS = dict(
+#: Roots of the per-user Windows app folders, used when %APPDATA%/%LOCALAPPDATA%/
+#: %TEMP% are absent (e.g. some service accounts). ``~`` is expanded at resolution
+#: time. These are spelled as Windows literals on purpose: they describe the
+#: Windows convention, so they must not be built with the *running* platform's
+#: separator (that would produce '~/AppData/Roaming' when read from POSIX).
+_WINDOWS_ROAMING_DEFAULT = r"~\AppData\Roaming"
+_WINDOWS_LOCAL_DEFAULT = r"~\AppData\Local"
+_WINDOWS_TEMP_DEFAULT = r"~\AppData\Local\Temp"
+
+
+def app_folder_standards(os_name: str = os.name) -> dict:
+    """Return the ``{folder_kind: FolderSpec}`` table for the given ``os.name``.
+
+    This is the *single* place where config2py branches on the operating
+    system: everything else consumes the returned table.  Exposing it as a
+    function (rather than an ``if`` at import time) keeps the branch testable
+    on any platform -- callers can ask for the table of an OS they are not
+    running on.
+
+    Args:
+        os_name: An ``os.name`` value; ``"nt"`` selects the Windows standards,
+            anything else selects the XDG Base Directory standards.
+
+    >>> app_folder_standards("nt")["cache"]
+    FolderSpec(env_var='LOCALAPPDATA', default_path='~\\\\AppData\\\\Local', subpath='Temp')
+    >>> app_folder_standards("posix")["cache"]
+    FolderSpec(env_var='XDG_CACHE_HOME', default_path='~/.cache', subpath='')
+    """
+    if os_name == "nt":
+        return dict(
+            config=FolderSpec("APPDATA", _WINDOWS_ROAMING_DEFAULT),
+            data=FolderSpec("LOCALAPPDATA", _WINDOWS_LOCAL_DEFAULT),
+            # Note the ``subpath``: %LOCALAPPDATA% is also the *data* root, so
+            # cache must be a sub-folder of it -- otherwise clearing the cache
+            # would wipe the user's data.
+            cache=FolderSpec("LOCALAPPDATA", _WINDOWS_LOCAL_DEFAULT, "Temp"),
+            state=FolderSpec("LOCALAPPDATA", _WINDOWS_LOCAL_DEFAULT),
+            runtime=FolderSpec("TEMP", _WINDOWS_TEMP_DEFAULT),
+        )
+    return dict(
         config=FolderSpec("XDG_CONFIG_HOME", "~/.config"),
         data=FolderSpec("XDG_DATA_HOME", "~/.local/share"),
         cache=FolderSpec("XDG_CACHE_HOME", "~/.cache"),
         state=FolderSpec("XDG_STATE_HOME", "~/.local/state"),
         runtime=FolderSpec("XDG_RUNTIME_DIR", "/tmp"),
     )
+
+
+APP_FOLDER_STANDARDS = app_folder_standards()
 
 
 AppFolderKind = Literal["config", "data", "cache", "state", "runtime"]
@@ -306,13 +347,26 @@ DFLT_APP_FOLDER_KIND: AppFolderKind = "config"  # type: ignore (for <3.11)
 
 def system_default_for_app_data_folder(
     folder_kind: AppFolderKind = DFLT_APP_FOLDER_KIND,  # type: ignore (for <3.11)
+    *,
+    standards: Optional[dict] = None,
 ) -> str:
-    """Get the system default for the app data folder."""
-    # Platform-specific specs: (env_var, default_path)
+    """Get the system default folder for ``folder_kind``.
 
-    # Same logic for both platforms: check env var, then use default
-    env_var, default = APP_FOLDER_STANDARDS[folder_kind]
-    return os.path.expanduser(os.getenv(env_var, default))
+    The root is the value of the platform's standard environment variable for
+    that kind, falling back to the spec's ``default_path``; the spec's
+    ``subpath`` (usually empty) is then appended.
+
+    Args:
+        folder_kind: One of 'config', 'data', 'cache', 'state', 'runtime'.
+        standards: The ``{folder_kind: FolderSpec}`` table to resolve against.
+            Defaults to the running platform's (``APP_FOLDER_STANDARDS``);
+            pass another platform's table to resolve as that platform would.
+    """
+    if standards is None:
+        standards = APP_FOLDER_STANDARDS
+    env_var, default, subpath = standards[folder_kind]
+    root = os.path.expanduser(os.getenv(env_var, default))
+    return os.path.join(root, subpath) if subpath else root
 
 
 DFLT_CONFIG_FOLDER = system_default_for_app_data_folder("config")
@@ -362,10 +416,13 @@ def get_app_rootdir(
 
     Note: The default root folder follows XDG Base Directory standards on Unix/Linux/macOS.
     You can override this by setting environment variables:
-    - CONFIG2PY_CONFIG_FOLDER, CONFIG2PY_DATA_FOLDER, CONFIG2PY_CACHE_FOLDER, etc.
-      (highest priority, overrides everything)
-    - XDG_CONFIG_HOME, XDG_DATA_HOME, XDG_CACHE_HOME, etc.
-      (standard XDG override)
+    - CONFIG2PY_CONFIG_DIR, CONFIG2PY_DATA_DIR, CONFIG2PY_CACHE_DIR, etc.
+      (highest priority, overrides everything, and works on **every** platform --
+      see ``config2py_env_var`` for the full list of names)
+    - The platform's own standard variable: XDG_CONFIG_HOME, XDG_DATA_HOME,
+      XDG_CACHE_HOME, etc. on Unix/Linux/macOS; APPDATA / LOCALAPPDATA / TEMP on
+      Windows. The XDG variables are a POSIX standard and are **not** consulted on
+      Windows -- use the CONFIG2PY_* variables above for platform-neutral overrides.
     - If neither is set, uses platform defaults
 
     Examples:
@@ -440,10 +497,19 @@ def get_app_folder(
     Returns:
         str: Path to the app directory.
 
-    By default, the app will be "config2py" and folder_kind will be "config":
+    By default, the app will be "config2py" and folder_kind will be "config".
+    The exact text of the path is platform-specific (``~/.config/config2py`` under
+    the XDG standards, ``%APPDATA%\\config2py`` on Windows), so we assert the
+    properties that hold everywhere: it is an absolute path named after the app,
+    sitting directly inside the 'config' root directory.
 
-    >>> get_app_folder()  # doctest: +ELLIPSIS
-    '.../.config/config2py'
+    >>> folder = get_app_folder()
+    >>> os.path.isabs(folder)
+    True
+    >>> os.path.basename(folder)
+    'config2py'
+    >>> os.path.dirname(folder) == get_app_rootdir('config')
+    True
 
     You can specify a different app name and folder kind:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,5 +73,12 @@ convention = "google"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-testpaths = ["tests"]
-doctest_optionflags = ["NORMALIZE_WHITESPACE", "ELLIPSIS"]
+# The package dir, not "tests": there is no top-level tests/ directory (tests live
+# in config2py/tests/). Naming a non-existent path made pytest emit
+# PytestConfigWarning and silently fall back to recursive discovery from the CWD.
+testpaths = ["config2py"]
+# Kept in sync with what the wads run-tests-uv CI action passes on the command
+# line (-o doctest_optionflags='ELLIPSIS IGNORE_EXCEPTION_DETAIL'), which
+# overrides this setting. Diverging here means doctests that pass locally can
+# fail in CI (and vice versa) -- notably NORMALIZE_WHITESPACE, which CI does not set.
+doctest_optionflags = ["ELLIPSIS", "IGNORE_EXCEPTION_DETAIL"]


### PR DESCRIPTION
Two independent bugs in `config2py/base.py`, same file and roughly the same size, fixed together.

## 1. `save_to` as a callable saver raised `UnboundLocalError`

`SaveTo = Optional[Union[MutableMapping, KTSaver]]` explicitly advertises callable savers, and `user_gettable(save_to=...)` is re-exported from `__init__` — but the callable branch was never implemented:

```python
if save_to is not None and save_condition(val):
    if hasattr(save_to, "__setitem__"):
        save_to_func = save_to.__setitem__
    save_to_func(key, val)      # <-- unbound when save_to is a callable
```

Repro before the fix:

```
>>> ask_user_for_key('K', save_to=lambda k, v: None, user_asker=lambda p: 'V')
UnboundLocalError: cannot access local variable 'save_to_func' where it is not associated with a value
```

Worse inside `user_gettable`: `FuncBasedGettableContainer` catches all exceptions by default, so the `UnboundLocalError` was swallowed into a `KeyError` and the user's value was silently dropped.

**Fix.** A `_resolve_saver` function is now the single place the `SaveTo` union is interpreted:

- `__setitem__` when present -> save through it
- else callable -> use it as the saver
- else -> `TypeError` naming the offending type

Resolution is idempotent and happens up front (and the resolved saver is what gets carried into the curried form), so an unusable `save_to` is reported when it is *specified* rather than after the user has already typed a value that then cannot be saved.

Behaviour is unchanged for existing callers: the mapping branch still dispatches on `hasattr(.., '__setitem__')` rather than `isinstance(.., MutableMapping)`, so write-only stores keep working.

`ask_user_for_key` also gained the docstring it was missing.

## 2. `KeyError` leaked the rejected credential

`FuncBasedGettableContainer.__getitem__` interpolated both the rejected value `v` and the upstream exception text `e` into its `KeyError`. `v` is often a credential (that is precisely why it is being validated), and SDK exception text routinely echoes the rejected token back. These `KeyError`s propagate through `ChainMap` lookups and are typically logged by the calling app.

Now `raise KeyError(k) from e` (and `raise KeyError(k)` for the invalid-value case). The message is just the key, `args[0]` stays the key per the `Mapping` convention, and the upstream exception remains reachable via `__cause__` for anyone who legitimately wants it.

Closes #14

## Tests

New `config2py/tests/test_base.py` — there was previously no test exercising `save_to` at all. It covers a dict saver, a `__setitem__`-only (non-`MutableMapping`) store, a callable saver, the `TypeError` branch, the fail-before-prompting property, `save_condition`, both `user_gettable` paths, `__contains__`, and asserts the secret appears in neither `str()` nor `repr()` of the raised `KeyError` while `__cause__` still carries it.

**8 of the 13 new tests failed before the change** (the other 5 are behaviour-preservation guards that passed both before and after).

Suite: 90 passed / 1 skipped before -> **105 passed / 1 skipped** after (`pytest --doctest-modules config2py`). `ruff` and `black --check` clean.

Two doctests in the `FuncBasedGettableContainer` docstring asserted the old leaky messages and were updated to the new ones (plus a new doctest showing the exception chain). Flagging that explicitly since it is a deliberate change to existing tests.

## Dependents gate

Ran the full dependent set via the local runner, before and after.

- Baseline (default branch): 26 pass, 2 fail, 1 tests-disabled
- With this branch: same 2 pre-existing failures, everything else green

The two pre-existing failures (`smart-cv` collection errors, `yp` doctest failures) are identical before and after and unrelated to this change. `hubcap` flapped during the run because its checkout was being edited concurrently; a back-to-back run pinned to each branch gives an identical `12 passed` both ways.

Also ran the explicitly requested extras: `dol` (510 passed, 2 skipped), `pyckup` (2 passed), `unbox` (48 passed), `py2store`, `rh`, `xdol`, `aix`, `oa` all pass. `odat` fails to collect with a pre-existing `NameError` of its own, identically on both branches.

https://claude.ai/code/session_01Kug7UUbVeCQgruvNXUq63c